### PR TITLE
Fix not translated plots levels

### DIFF
--- a/NSOV1script.R
+++ b/NSOV1script.R
@@ -278,8 +278,10 @@ server <- function(input, output, session) {
   dropdownFilteredData <- reactive({
     req(input$dropdown)
     if (input$dropdown == "All") filtered_data <- imported_data %>%
+        dplyr::mutate(secondaryText = tr()$t(secondaryText)) %>%
         dplyr::filter(Level == "ADM0")
     else filtered_data <- imported_data %>%
+        dplyr::mutate(secondaryText = tr()$t(secondaryText)) %>%
         dplyr::filter(ADM1 == input$dropdown)
   })
   
@@ -635,10 +637,9 @@ server <- function(input, output, session) {
   
   output$firstPage_Sex <- renderPlot({
     sexPlot <- dropdownFilteredData() %>%
-      
       filter(Metric == "Population" & Type %in% c("Male", "Female")) %>%
       mutate(Sex = fct_relevel(Type, "Female", "Male")) %>%
-      ggplot(aes(x = Type, y = Value, label = secondaryText)) +
+      ggplot(aes(x = secondaryText, y = Value)) +
       geom_bar(stat = "identity") +
       ggtitle(i18n$t("Population by Sex")) +
       ylab(i18n$t("People")) +
@@ -668,7 +669,7 @@ server <- function(input, output, session) {
     urbanRuralPlot <- dropdownFilteredData() %>%
       filter(Metric == "Population" & Type %in% c("Urban", "Rural")) %>%
       mutate(UrbanRural = fct_relevel(UrbanRural, "Urban", "Rural")) %>%
-      ggplot(aes(x = Type, y = Value, label = secondaryText)) +
+      ggplot(aes(x = secondaryText, y = Value)) +
       geom_bar(stat = "identity") +
       ggtitle(i18n$t("Population by Urban / Rural Residence")) +
       ylab(i18n$t("People")) +
@@ -736,8 +737,6 @@ server <- function(input, output, session) {
     req(tr())
     newOptions <- purrr::map(lang_options, ~ list(key = .x$key, text = tr()$t(.x$text)))
     updateDropdown.shinyInput(session = session, inputId = "language", options = newOptions)
-    imported_data <- imported_data %>%
-      dplyr::mutate(secondaryText = tr()$t(secondaryText))
   })
   
 


### PR DESCRIPTION
There were 2 root causes of plots labels not being translated that I've spotted:
1. `Type` column was used for x-axis in 2 plots, translated values are stored in `secondaryText` so non-translated values were shown on the plots
2. This assignment:
```r
# lines 739-740
imported_data <- imported_data %>%
  dplyr::mutate(secondaryText = tr()$t(secondaryText))
```
affected `imported_data` only in the scope of the observe expression it was called in. To expose `imported_data` translated in such way for other expressions in server we would need to create another `reactive` which would store `imported_data`. To propagate effect of this translation I haven't created such object but I've used `dropdownFilteredData` reactive to store the translated table (since this reactive is already used by the plots).